### PR TITLE
Change artifactID in pom.xml to match the service name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
 		<version>2.6.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>si</groupId>
-	<artifactId>banka</artifactId>
+	<groupId>si.banka</groupId>
+	<artifactId>korisnicki_servis</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>banka</name>
 	<description>Capstone project Banka</description>


### PR DESCRIPTION
`artifactId` je promenjen u `korisnicki_servis`, tj. naziv ovog mikroservisa. Razlog ove promene je SonarCloud integracija.