### PR TITLE
Use Zoho instead of GMail for mail-service

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -2,3 +2,5 @@ berza.alphavantage.apikey=TOKEN
 ALPHAVANTAGE_TOKEN=TOKEN
 NASDAQ_API_KEY=TOKEN
 DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE=false
+spring.mail.username=email@example.com
+spring.mail.password=password=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,9 +95,8 @@ services:
   email-servis:
     image: ghcr.io/raf-si-2021/banka-mail-service:latest
     build: ./mail-service
+    env_file: .env
     environment:
-      spring.mail.username: "email"
-      spring.mail.password: "password"
       spring.activemq.broker-url: tcp://artemis:61616
     ports:
       - "8081:8081"

--- a/mail-service/src/main/resources/application.properties
+++ b/mail-service/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=8081
 
 #Mail properties
-spring.mail.host=smtp.gmail.com
+spring.mail.host=smtp.zoho.com
 spring.mail.port=587
 
 spring.mail.properties.mail.smtp.auth=true


### PR DESCRIPTION
[GMail od 30. maja više ne dozvoljava SMTP pristup nesigurnim aplikacijama](https://support.google.com/accounts/answer/6010255?hl=en), pa više nismo u mogućnosti da šaljemo mejlove preko GMail adrese. Umesto GMail-a, možemo da koristimo Zoho koji dozvoljava SMTP pristup. Napravio sam mejl adresu i sve radi kako treba.