### PR TITLE
Temporary disable margins account

### DIFF
--- a/racun-service/src/main/java/rs/edu/raf/banka/racun/bootstrap/BootstrapData.java
+++ b/racun-service/src/main/java/rs/edu/raf/banka/racun/bootstrap/BootstrapData.java
@@ -84,7 +84,8 @@ public class BootstrapData implements CommandLineRunner {
             valutaRepository.saveAll(valute);
 
             racunService.createKesRacun();
-            racunService.createMarginRacun();
+            // TODO: Ukljuciti ovo nakon sto margins racun bude ispravno integrisan sa sredstvima i kapitalom.
+//            racunService.createMarginRacun();
         }
 
 

--- a/racun-service/src/main/java/rs/edu/raf/banka/racun/model/SredstvaKapital.java
+++ b/racun-service/src/main/java/rs/edu/raf/banka/racun/model/SredstvaKapital.java
@@ -39,6 +39,5 @@ public class SredstvaKapital {
     private Double pozajmljenaSredstva;
 
     private Double maintenanceMargin;
-    @Column(name = "marginCall", columnDefinition = "boolean default false")
-    private Boolean marginCall;
+    private Boolean marginCall = false;
 }

--- a/racun-service/src/main/java/rs/edu/raf/banka/racun/service/impl/RacunService.java
+++ b/racun-service/src/main/java/rs/edu/raf/banka/racun/service/impl/RacunService.java
@@ -41,7 +41,7 @@ public class RacunService {
         racun.setBrojRacuna(UUID.randomUUID());
         racun.setTipRacuna(RacunType.MARGINS_RACUN);
         racunRepository.save(racun);
-        sredstvaKapitalService.pocetnoStanjeMarzniRacun(racun.getBrojRacuna(), KapitalType.AKCIJA, null);
+        sredstvaKapitalService.pocetnoStanjeMarzniRacun(racun.getBrojRacuna(), KapitalType.NOVAC, -1L);
 
         return racun;
     }


### PR DESCRIPTION
Sredstva i kapital trenutno ne podržavaju više tipova računa (keš i margins), pa nastaju problemi pri trgovini. Da API ne bi bagovao, za sada ćemo isključiti margins naloge, a onda ih uključiti kad krenemo da radimo na njima.